### PR TITLE
fix(AMA-9701): fix map crush on calling getzoomlevel

### DIFF
--- a/plugin/ios/Plugin/CapacitorGoogleMapsPlugin.swift
+++ b/plugin/ios/Plugin/CapacitorGoogleMapsPlugin.swift
@@ -1345,6 +1345,12 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
             }
 
             try DispatchQueue.main.sync {
+                // GMapView is nilled out on the main queue during map destroy, so it can already be
+                // gone by the time this block runs. Guard instead of force-unwrapping to avoid a crash.
+                guard let gMapView = map.mapViewController.GMapView else {
+                    throw GoogleMapErrors.unhandledError("Google Map view is not available.")
+                }
+
                 guard let bounds = map.getMapLatLngBounds() else {
                     throw GoogleMapErrors.unhandledError("Google Map Bounds could not be found.")
                 }
@@ -1352,7 +1358,7 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
                 call.resolve(
                     formatMapBoundsForResponse(
                         bounds: bounds,
-                        cameraPosition: map.mapViewController.GMapView.camera
+                        cameraPosition: gMapView.camera
                     )
                 )
             }
@@ -1371,9 +1377,14 @@ public class CapacitorGoogleMapsPlugin: CAPPlugin, GMSMapViewDelegate {
                 throw GoogleMapErrors.mapNotFound
             }
 
-            DispatchQueue.main.sync {
-                let zoom = map.mapViewController.GMapView.camera.zoom
-                call.resolve(["zoomLevel": zoom])
+            try DispatchQueue.main.sync {
+                // GMapView is nilled out on the main queue during map destroy, so it can already be
+                // gone by the time this block runs. Guard instead of force-unwrapping to avoid a crash.
+                guard let gMapView = map.mapViewController.GMapView else {
+                    throw GoogleMapErrors.unhandledError("Google Map view is not available.")
+                }
+
+                call.resolve(["zoomLevel": gMapView.camera.zoom])
             }
         } catch {
             handleError(call, error: error)

--- a/plugin/ios/Plugin/Map.swift
+++ b/plugin/ios/Plugin/Map.swift
@@ -748,10 +748,12 @@ public class Map {
         DispatchQueue.main.sync {
             let newCamera = GMSCameraPosition(latitude: lat, longitude: lng, zoom: zoom, bearing: bearing, viewingAngle: angle)
 
+            // Use the map view captured by the guard above: the GMapView property is nilled out
+            // on the main queue during map destroy and re-reading it here could force-unwrap nil.
             if animate {
-                self.mapViewController.GMapView.animate(to: newCamera)
+                gMapView.animate(to: newCamera)
             } else {
-                self.mapViewController.GMapView.camera = newCamera
+                gMapView.camera = newCamera
             }
         }
 
@@ -879,13 +881,15 @@ public class Map {
     }
 
     func getMapLatLngBounds() -> GMSCoordinateBounds? {
-        return GMSCoordinateBounds(region: self.mapViewController.GMapView.projection.visibleRegion())
+        guard let gMapView = self.mapViewController.GMapView else { return nil }
+        return GMSCoordinateBounds(region: gMapView.projection.visibleRegion())
     }
 
     func fitBounds(bounds: GMSCoordinateBounds, padding: CGFloat) {
         DispatchQueue.main.sync {
+            guard let gMapView = self.mapViewController.GMapView else { return }
             let cameraUpdate = GMSCameraUpdate.fit(bounds, withPadding: padding)
-            self.mapViewController.GMapView.animate(with: cameraUpdate)
+            gMapView.animate(with: cameraUpdate)
         }
     }
 


### PR DESCRIPTION
## Description
Fixed crush after 2.3.0 release.
The crash was caused by frequent calls to getZoomLevel(). It should now be stable. ✅

## Change Type
- [ ] Fix

## Rationale / Problems Fixed
Fixed crush after 2.3.0 release.

## Platforms Affected
- [ ] iOS